### PR TITLE
Potential fix for code scanning alert no. 165: Use of externally-controlled format string

### DIFF
--- a/src/router/RouterService.ts
+++ b/src/router/RouterService.ts
@@ -179,7 +179,7 @@ export class RouterService implements Service {
       this.navigationState.currentPage = newPage;
       this.navigationState.currentPath = routeContext.getPath();
     } catch (error) {
-      console.error(`Failed to load page for route ${path}:`, error);
+      console.error('Failed to load page for route: %s', path, error);
       
       // Reset navigation state on error
       this.navigationState.isNavigating = false;


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/165](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/165)

The ideal fix is to ensure that no user-controlled data is used directly as a format string argument in any console method that supports format specifiers. Instead, log output should always use a static format string with explicit substitution placeholders and pass user data as extra arguments. In this instance (line 182), rather than using a template literal (`` `Failed to load page for route ${path}:` ``) which may inadvertently be treated as a format string, use `"Failed to load page for route: %s"` and pass `path` as an extra argument. This eliminates the possibility of format specifier injection and ensures the log always outputs the intended message.

Edit required: In file `src/router/RouterService.ts`, change line 182 from:
```
console.error(`Failed to load page for route ${path}:`, error);
```
to:
```
console.error('Failed to load page for route: %s', path, error);
```
No new methods or extra imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
