### PR TITLE
Potential fix for code scanning alert no. 4: Missing origin verification in `postMessage` handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,12 @@ import { MessagesLogAdapter } from "./adapters/MessagesLogAdapter";
 import { Logger } from "./logging/Logger";
 
 export class OpinionApp {
+  // Trusted origins for postMessage, adjust as needed
+  private static readonly TRUSTED_MESSAGE_ORIGINS: string[] = [
+    'http://localhost:3000', // Add your development URL(s)
+    'https://your-production-domain.com' // Add production URL(s)
+  ];
+
   private initialized: boolean = false;
   private apiService: MockApiService;
   private routerService: RouterService | null = null;
@@ -74,6 +80,11 @@ export class OpinionApp {
   private setupEventListeners(): void {
     // Handle postMessage events for testing (e.g., from test-positioning.html iframe)
     window.addEventListener("message", (event) => {
+      // Verify the origin of the message
+      if (!OpinionApp.TRUSTED_MESSAGE_ORIGINS.includes(event.origin)) {
+        this.logger.warn('Blocked postMessage from untrusted origin:', event.origin);
+        return;
+      }
 
       if (event.data && event.data.action) {
         switch (event.data.action) {


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/4](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/4)

**How to fix the problem:**
The best general practice is to verify the `event.origin` property of the message against a whitelist of trusted origins before acting on the received message. If the origin is not trusted, the handler should ignore the message (and optionally log or warn).

**Best single fix for this code:**
- In the anonymous handler registered at `window.addEventListener("message", ...)`, add a check *before* any processing of `event.data` to ensure `event.origin` matches one (or more) allowed origins.  
- The trusted origin(s) can be hardcoded (for a single-tenant application) or passed as a config/constant (for easier future management and multi-tenant support).  
- If the origin does not match, the function should return early, optionally logging a warning.

**File/line to change:**
- File: `src/app.ts`
- Line: 76-90 (the entire message event handler)

**What is needed:**
- A constant list or variable with allowed origins at the top of the file or inside the class  
- Updating the event handler in `setupEventListeners` to bail out unless the origin matches.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
