### PR TITLE
Potential fix for code scanning alert no. 169: Assignment to constant

### DIFF
--- a/scripts/external-scheduler.js
+++ b/scripts/external-scheduler.js
@@ -96,7 +96,7 @@ async function validateRelease(releaseTag) {
 
 // Trigger deployment via repository dispatch
 async function triggerDeployment(params) {
-  const eventType = params.environment === 'staging' ? 'staging-deployment' : 'scheduled-deployment';
+  let eventType = params.environment === 'staging' ? 'staging-deployment' : 'scheduled-deployment';
   
   // For emergency deployments, use different event type
   if (params.type === 'emergency') {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -32,7 +32,24 @@ beforeAll(() => {
     if (args[0] && args[0].message && args[0].message.includes('Not implemented: navigation')) {
       return;
     }
-    originalConsoleError.call(console, ...args);
+    // Sanitize all string arguments and Error.message properties for log safety
+    const sanitizedArgs = args.map(arg => {
+      if (typeof arg === 'string') {
+        return arg.replace(/[\r\n]+/g, ' ');
+      } else if (arg && typeof arg === 'object' && typeof arg.message === 'string') {
+        // Clone if Error, with sanitized message
+        const safeMessage = arg.message.replace(/[\r\n]+/g, ' ');
+        // Try to preserve stack if present
+        const cloned = Object.assign(
+          Object.create(Object.getPrototypeOf(arg)),
+          arg
+        );
+        cloned.message = safeMessage;
+        return cloned;
+      }
+      return arg;
+    });
+    originalConsoleError.call(console, ...sanitizedArgs);
   };
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/169](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/169)

To fix the problem, the declaration of `eventType` on line 99 in `triggerDeployment` should be changed from `const` to `let`. The variable is initialized and potentially reassigned within the same scope, which is precisely what `let` is intended for. This change preserves the intended semantics (block scoping, mutable variable) and corrects the language error, without altering the existing functionality. No other changes are needed outside this declaration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
