### PR TITLE
Potential fix for code scanning alert no. 170: Log injection

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -33,19 +33,24 @@ beforeAll(() => {
       return;
     }
     // Sanitize all string arguments and Error.message properties for log safety
+    const sanitizeObjectStrings = obj => {
+      if (!obj || typeof obj !== 'object') return obj;
+      const cloned = Object.assign(
+        Object.create(Object.getPrototypeOf(obj)),
+        obj
+      );
+      for (const key in cloned) {
+        if (typeof cloned[key] === 'string') {
+          cloned[key] = cloned[key].replace(/[\r\n]+/g, ' ');
+        }
+      }
+      return cloned;
+    };
     const sanitizedArgs = args.map(arg => {
       if (typeof arg === 'string') {
         return arg.replace(/[\r\n]+/g, ' ');
-      } else if (arg && typeof arg === 'object' && typeof arg.message === 'string') {
-        // Clone if Error, with sanitized message
-        const safeMessage = arg.message.replace(/[\r\n]+/g, ' ');
-        // Try to preserve stack if present
-        const cloned = Object.assign(
-          Object.create(Object.getPrototypeOf(arg)),
-          arg
-        );
-        cloned.message = safeMessage;
-        return cloned;
+      } else if (arg && typeof arg === 'object') {
+        return sanitizeObjectStrings(arg);
       }
       return arg;
     });


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/170](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/170)

To robustly fix the log injection risk:
- **Sanitize all string-valued properties of any object passed to `console.error`.**  
- Currently, only the `.message` property of error objects is sanitized, while other properties (like `.stack` or custom error fields) may remain unsanitized and user-controlled.
- Update the wrapper so that for any object (including errors), *all* string properties are sanitized (especially those likely to be displayed or used by Jest's reporters), i.e., replace newline characters in *every* string-valued property.
- Make these changes in `tests/setup.ts`, specifically in the mock implementation of `console.error`.
- No external dependencies are needed for this fixer.
- Edits will be within the function starting at line 27 and in the sanitization logic around lines 36-51.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
