### PR TITLE
Potential fix for code scanning alert no. 99: Useless assignment to local variable

### DIFF
--- a/src/pages/DebugPage.ts
+++ b/src/pages/DebugPage.ts
@@ -1095,7 +1095,7 @@ export class DebugPage extends PageComponent {
       ) : false;
       
       // EventBus status
-      let eventBusStatus = 'Unknown';
+      let eventBusStatus;
       try {
         const ctx = this.layoutContext as any;
         if (ctx.getEventBus && typeof ctx.getEventBus === 'function') {


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/99](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/99)

To fix this issue, simply remove the redundant initial assignment `eventBusStatus = 'Unknown'` since it serves no purpose: all branches of the logic reassign this variable before it's read. Thus, change the declaration to a `let` without initializer, i.e. `let eventBusStatus;`. This clarifies intent and eliminates the useless assignment. Only lines around 1098 (declaration of `eventBusStatus`) need editing; no additional imports or logic changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
