### PR TITLE
Potential fix for code scanning alert no. 125: Superfluous trailing arguments

### DIFF
--- a/src/contexts/LayoutContextImpl.ts
+++ b/src/contexts/LayoutContextImpl.ts
@@ -128,7 +128,7 @@ export class LayoutContextImpl implements LayoutContext {
   private setupViewportObserver(): void {
     // Use ResizeObserver for better performance if available
     if (window.ResizeObserver) {
-      this.resizeObserver = new ResizeObserver((_entries) => {
+      this.resizeObserver = new ResizeObserver(() => {
         this.handleViewportChange();
       });
       this.resizeObserver.observe(document.body);


### PR DESCRIPTION
Potential fix for [https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/125](https://github.com/inqwise-opinion/opinion-front-ui/security/code-scanning/125)

To fix this issue, remove the unused `_entries` parameter from the arrow function provided to the `ResizeObserver` in the `setupViewportObserver` method. Since the function does not reference or utilize this argument, it is safe and more idiomatic to exclude it. Only the code region in `src/contexts/LayoutContextImpl.ts` containing `this.resizeObserver = new ResizeObserver((_entries) => { this.handleViewportChange(); });` needs to be changed so that the arrow function takes zero arguments, i.e., simply `() => { this.handleViewportChange(); }`. No further imports, method, or definition edits are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
